### PR TITLE
[Productionization] Removing four-gram dict and setting output

### DIFF
--- a/lib/logstash/filters/gramdict.rb
+++ b/lib/logstash/filters/gramdict.rb
@@ -15,7 +15,6 @@
 # and anomalies in log entries.
 class GramDict
   def initialize
-    @four_gram_dict = {}
     @tri_gram_dict = {}
     @double_gram_dict = {}
     @single_gram_dict = {}
@@ -72,23 +71,6 @@ class GramDict
       @tri_gram_dict[gram] += 1
     else
       @tri_gram_dict[gram] = 1
-    end
-  end
-
-  # Method: four_gram_upload
-  # This method manages the frequency count of four grams (sequences of four words or tokens) in a hash map.
-  # It either increments the existing count or initializes it to 1 if the four gram is new.
-  #
-  # Parameters:
-  # gram: A string that denotes the four gram to be updated in the hash map.
-  #
-  # Returns:
-  # Nothing. The @four_gram_dict is updated accordingly.
-  def four_gram_upload(gram)
-    if @four_gram_dict.key?(gram)
-      @four_gram_dict[gram] += 1
-    else
-      @four_gram_dict[gram] = 1
     end
   end
 

--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -19,13 +19,14 @@ module LogStash
         @gramdict = GramDict.new
         @preprocessor = Preprocessor.new(@gramdict, '<date> <time> <message>', 'message')
 
-        # populate gramdict with seed logs 
-        if @seed_logs_path 
-          ::File.open(@seed_logs_path, "r") do |seed_logs|
-            seed_logs.each_line do |seed_log|
-              # TODO: Here, we are parsing every seed log file when we don't need to, might need to separate these steps out
-              @preprocessor.process_log_event(seed_log)
-            end
+        # populate gramdict with seed logs
+        return unless @seed_logs_path
+
+        ::File.open(@seed_logs_path, 'r') do |seed_logs|
+          seed_logs.each_line do |seed_log|
+            # TODO: Here, we are parsing every seed log file when we don't need to,
+            # might need to separate these steps out
+            @preprocessor.process_log_event(seed_log)
           end
         end
       end

--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -37,13 +37,13 @@ module LogStash
           processed_log = @preprocessor.process_log_event(event.get(@source_field))
 
           if processed_log
-            event_string, template_string = processed_log
+            template_string, dynamic_tokens = processed_log
 
             # Set the new values in the returned event
-            event.set('event_string', event_string)
             event.set('template_string', template_string)
+            event.set('dynamic_tokens', dynamic_tokens)
           else
-            event.set('event_string', nil)
+            event.set('dynamic_tokens', nil)
             event.set('template_string', nil)
           end
 

--- a/lib/logstash/filters/preprocessor.rb
+++ b/lib/logstash/filters/preprocessor.rb
@@ -124,11 +124,11 @@ class Preprocessor
 
     # Parse the log based on the pre-existing gramdict data
     parser = Parser.new(@gram_dict, 0.5)
-    event_string, template_string = parser.parse(tokens)
+    template_string, dynamic_tokens = parser.parse(tokens)
 
     # Update gram_dict
     @gram_dict.upload_grams(tokens)
 
-    [event_string, template_string]
+    [template_string, dynamic_tokens]
   end
 end

--- a/spec/filters/gramdict_spec.rb
+++ b/spec/filters/gramdict_spec.rb
@@ -45,18 +45,6 @@ describe GramDict do
     end
   end
 
-  describe '#four_gram_upload' do
-    let(:four_gram) { 'example four gram' }
-
-    it 'correctly updates the four gram count' do
-      expect { subject.four_gram_upload(four_gram) }
-        .to change { subject.instance_variable_get(:@four_gram_dict)[four_gram] }.from(nil).to(1)
-
-      expect { subject.four_gram_upload(four_gram) }
-        .to change { subject.instance_variable_get(:@four_gram_dict)[four_gram] }.from(1).to(2)
-    end
-  end
-
   describe '#upload_grams' do
     context 'with one token' do
       let(:tokens) { ['token1'] }

--- a/spec/filters/parser_spec.rb
+++ b/spec/filters/parser_spec.rb
@@ -76,24 +76,29 @@ describe Parser do
       tokens = tokens_list[1]
       dynamic_indices = [1]
 
-      template = parser.template_generator(tokens, dynamic_indices)
+      template, dynamic_tokens = parser.template_generator(tokens, dynamic_indices)
+
+      # template = template_generator_return_value[0]
+      # dynamic_tokens = template_generator_return_value[1]
+
       expected_template = 'token2a <*> token2c '
+      expected_dynamic_tokens = { 'dynamic_token_1' => 'token2b' }
 
       expect(template).to eq(expected_template)
+      expect(dynamic_tokens).to eq(expected_dynamic_tokens)
     end
   end
 
   describe '#parse' do
     it 'parses the tokens list and generates strings in the correct format' do
       tokens = tokens_list[1]
-      event_string, template_string = parser.parse(tokens)
-
-      expected_event_string = "e5a48,token2a token2b token2c \n"
+      template_string, dynamic_tokens = parser.parse(tokens)
 
       expected_template_string = 'token2a token2b token2c '
+      expected_dynamic_tokens = {}
 
-      expect(event_string).to eq(expected_event_string)
       expect(template_string).to eq(expected_template_string)
+      expect(dynamic_tokens).to eq(expected_dynamic_tokens)
     end
   end
 end

--- a/spec/filters/pilar_spec.rb
+++ b/spec/filters/pilar_spec.rb
@@ -27,8 +27,8 @@ describe LogStash::Filters::Pilar do
       pilar_filter.filter(event)
     end
 
-    it 'correctlys sets the event_string field' do
-      expect(event.get('event_string')).not_to be_nil
+    it 'correctly sets the dynamic_tokens field' do
+      expect(event.get('dynamic_tokens')).not_to be_nil
     end
 
     it 'correctly sets the template_string field' do


### PR DESCRIPTION
Removed extraneous code for the four-gram dict. 

I also cleaned up the output. The output will now look like the following:
```
{
   "template_string": "hello, user <*>!",
   "dynamic_tokens": { "dynamic_token_1" : "102930" },
   "raw_log" : "hello, user 102930!"
}
```
