### PR TITLE
[Productionization] Add parse flag into process_log_event

### DIFF
--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -26,7 +26,7 @@ module LogStash
           seed_logs.each_line do |seed_log|
             # TODO: Here, we are parsing every seed log file when we don't need to,
             # might need to separate these steps out
-            @preprocessor.process_log_event(seed_log)
+            @preprocessor.process_log_event(seed_log, false)
           end
         end
       end
@@ -34,7 +34,7 @@ module LogStash
       def filter(event)
         # Use the message from the specified source field
         if event.get(@source_field)
-          processed_log = @preprocessor.process_log_event(event.get(@source_field))
+          processed_log = @preprocessor.process_log_event(event.get(@source_field), true)
 
           if processed_log
             template_string, dynamic_tokens = processed_log

--- a/lib/logstash/filters/preprocessor.rb
+++ b/lib/logstash/filters/preprocessor.rb
@@ -111,20 +111,27 @@ class Preprocessor
   #
   # Parameters:
   # log_event [String] the log event to be processed
+  # parse? [String] a boolean that controls whether the log_event should be parsed. This will be set to False for
+  #                 seed log events.
   #
   # Returns:
   # event_string [String], template_string[String], which are useful for log analysis and pattern recognition.
   # It also updates the gram dict based on this information.
-  def process_log_event(log_event)
+  def process_log_event(log_event, parse)
+    template_string = nil
+    dynamic_tokens = nil
+
     # Split log event into tokens
     tokens = token_splitter(log_event)
 
     # If no tokens were returned, do not parse the logs and return
     return if tokens.nil?
 
-    # Parse the log based on the pre-existing gramdict data
-    parser = Parser.new(@gram_dict, 0.5)
-    template_string, dynamic_tokens = parser.parse(tokens)
+    if parse
+      # Parse the log based on the pre-existing gramdict data
+      parser = Parser.new(@gram_dict, 0.5)
+      template_string, dynamic_tokens = parser.parse(tokens)
+    end
 
     # Update gram_dict
     @gram_dict.upload_grams(tokens)

--- a/spec/filters/preprocessor_spec.rb
+++ b/spec/filters/preprocessor_spec.rb
@@ -47,7 +47,7 @@ describe Preprocessor do
     end
 
     it 'calls token_splitter with the log event' do
-      preprocessor.process_log_event(log_event)
+      preprocessor.process_log_event(log_event, true)
       expect(preprocessor).to have_received(:token_splitter).with(log_event)
     end
 
@@ -57,7 +57,7 @@ describe Preprocessor do
       before do
         allow(preprocessor).to receive(:token_splitter).and_return(tokens)
         allow(gram_dict).to receive(:upload_grams)
-        preprocessor.process_log_event(log_event)
+        preprocessor.process_log_event(log_event, true)
       end
 
       it 'calls upload_grams with extracted tokens' do
@@ -69,11 +69,33 @@ describe Preprocessor do
       before do
         allow(preprocessor).to receive(:token_splitter).and_return(nil)
         allow(gram_dict).to receive(:upload_grams)
-        preprocessor.process_log_event(log_event)
+        preprocessor.process_log_event(log_event, true)
       end
 
       it 'does not call upload_grams' do
         expect(gram_dict).not_to have_received(:upload_grams)
+      end
+    end
+
+    context 'when parse is set to false' do
+      before do
+        allow(Parser).to receive(:new).and_return(double('Parser', parse: nil))
+        preprocessor.process_log_event(log_event, false)
+      end
+
+      it 'does not call parser.parse' do
+        expect(Parser).not_to have_received(:new)
+      end
+    end
+
+    context 'when parse is set to true' do
+      before do
+        allow(Parser).to receive(:new).and_return(double('Parser', parse: nil))
+        preprocessor.process_log_event(log_event, true)
+      end
+
+      it 'does call parser.parse' do
+        expect(Parser).to have_received(:new)
       end
     end
   end


### PR DESCRIPTION
Previously, all log events that are sent to `Preprocessor.process_log_event` would be tokenized and parsed. However, we want to disable parsing for log events from seed logs.

This change includes a flag that can be set to false if we don't want to process a certain log event. Tests are also added.