### PR TITLE
Draft: Adding Testing Functionality and Config Params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,13 +5,13 @@ PATH
       logstash-core-plugin-api (~> 2.0)
 
 PATH
-  remote: /Users/aaronabraham/code/aaronabraham311/logstash-8.11.0/logstash-core-plugin-api
+  remote: /Users/kevinzhang/Documents/src/logstash-8.11.1/logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
       logstash-core (= 8.11.0)
 
 PATH
-  remote: /Users/aaronabraham/code/aaronabraham311/logstash-8.11.0/logstash-core
+  remote: /Users/kevinzhang/Documents/src/logstash-8.11.1/logstash-core
   specs:
     logstash-core (8.11.0-java)
       cgi (~> 0.3.6)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ output {
 }
 ```
 
+REALLY ANNOYING THING (I would love to find a fix): Go to the path you defined for your output, manually create the csv and add the following lines (logstash can't do this automatically somehow)
+
+```
+LineId,@timestamp,raw_log,template_string,EventId
+
+```
+
+
 [Copy this script](https://github.com/logpai/logparser/blob/main/logparser/utils/evaluator.py)  and add the following lines to the end of the script.
 
 ```

--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -34,7 +34,7 @@ module LogStash
           seed_logs.each_line do |seed_log|
             # TODO: Here, we are parsing every seed log file when we don't need to,
             # might need to separate these steps out
-            @preprocessor.process_log_event(seed_log, false)
+            @preprocessor.process_log_event(seed_log, 0.0, false)
           end
         end
       end
@@ -42,16 +42,16 @@ module LogStash
       def filter(event)
         # Use the message from the specified source field
         if event.get(@source_field)
-          processed_log = @preprocessor.process_log_event(event.get(@source_field), threshold)
+          processed_log = @preprocessor.process_log_event(event.get(@source_field), threshold, true)
           event.set('line_id',  @linenumber)
           @linenumber += 1
 
           if processed_log
-            event_string, template_string, template_id = processed_log
+            template_string, dynamic_tokens, template_id = processed_log
 
             # Set the new values in the returned event
-            event.set('dynamic_tokens', dynamic_tokens)
             event.set('template_string', template_string)
+            event.set('dynamic_tokens', dynamic_tokens)
             event.set('template_id', template_id)
           else
             event.set('dynamic_tokens', nil)

--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -70,7 +70,7 @@ module LogStash
           processed_log = @preprocessor.process_log_event(
             event.get(@source_field), @dynamic_token_threshold, true
           )
-          
+
           event.set('line_id', @linenumber)
           @linenumber += 1
 

--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -23,7 +23,7 @@ module LogStash
         @gramdict = GramDict.new
         @preprocessor = Preprocessor.new(@gramdict, logformat, content_specifier)
 
-        if threshold > 1 || threshold < 0
+        if threshold > 1 || threshold.negative?
           raise LogStash::ConfigurationError, "Threshold value #{threshold} is invalid. It must be between 0 and 1."
         end
 
@@ -43,7 +43,7 @@ module LogStash
         # Use the message from the specified source field
         if event.get(@source_field)
           processed_log = @preprocessor.process_log_event(event.get(@source_field), threshold, true)
-          event.set('line_id',  @linenumber)
+          event.set('line_id', @linenumber)
           @linenumber += 1
 
           if processed_log

--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -14,17 +14,25 @@ module LogStash
       # If this is not set, the filter will use the value of the "message" field by default.
       config :source_field, validate: :string, default: 'message'
       config :seed_logs_path, validate: :path, required: false
+      config :logformat, validate: :string, default: '<Date> <Time> <Content>'
+      config :content_specifier, validate: :string, default: 'Content'
+      config :threshold, validate: :number, default: 0.5
 
       def register
+        @linenumber = 1
         @gramdict = GramDict.new
-        @preprocessor = Preprocessor.new(@gramdict, '<date> <time> <message>', 'message')
+        @preprocessor = Preprocessor.new(@gramdict, logformat, content_specifier)
+
+        if threshold > 1 || threshold < 0
+          raise LogStash::ConfigurationError, "Threshold value #{threshold} is invalid. It must be between 0 and 1."
+        end
 
         # populate gramdict with seed logs 
         if @seed_logs_path 
           ::File.open(@seed_logs_path, "r") do |seed_logs|
             seed_logs.each_line do |seed_log|
               # TODO: Here, we are parsing every seed log file when we don't need to, might need to separate these steps out
-              @preprocessor.process_log_event(seed_log)
+              @preprocessor.process_log_event(seed_log, threshold)
             end
           end
         end
@@ -33,17 +41,21 @@ module LogStash
       def filter(event)
         # Use the message from the specified source field
         if event.get(@source_field)
-          processed_log = @preprocessor.process_log_event(event.get(@source_field))
+          processed_log = @preprocessor.process_log_event(event.get(@source_field), threshold)
+          event.set('line_id',  @linenumber)
+          @linenumber += 1
 
           if processed_log
-            event_string, template_string = processed_log
+            event_string, template_string, template_id = processed_log
 
             # Set the new values in the returned event
             event.set('event_string', event_string)
             event.set('template_string', template_string)
+            event.set('template_id', template_id)
           else
             event.set('event_string', nil)
             event.set('template_string', nil)
+            event.set('template_id', nil)
           end
 
           # include the raw log message

--- a/lib/logstash/filters/preprocessor.rb
+++ b/lib/logstash/filters/preprocessor.rb
@@ -47,9 +47,9 @@ class Preprocessor
     @template_to_template_id_counter = 0
 
     @general_regex = [
-      /([\w-]+\.)+[\w-]+(:\d+)/,  # url
-      /\/?([0-9]+\.){3}[0-9]+(:[0-9]+)?(:|)/,  # IP
-      /(?<=\W)(\-?\+?\d+)(?=\W)|[0-9]+$/,  # Numbers
+      /([\w-]+\.)+[\w-]+(:\d+)/, # url
+      %r{/?([0-9]+\.){3}[0-9]+(:[0-9]+)?(:|)}, # IP
+      /(?<=\W)(-?\+?\d+)(?=\W)|[0-9]+$/ # Numbers
     ]
 
     @regexes = regexes
@@ -91,15 +91,15 @@ class Preprocessor
   end
 
   def preprocess(log_line, regexes)
-    log_line = " " + log_line
+    log_line = " #{log_line}"
     regexes.each do |regex|
-      log_line = log_line.gsub(regex, "<*>")
+      log_line = log_line.gsub(regex, '<*>')
     end
 
     @general_regex.each do |regex|
-      log_line = log_line.gsub(regex, "<*>")
+      log_line = log_line.gsub(regex, '<*>')
     end
-    return log_line
+    log_line
   end
 
   # Splits a log line into tokens based on a given format and regular expression.

--- a/lib/logstash/filters/preprocessor.rb
+++ b/lib/logstash/filters/preprocessor.rb
@@ -140,7 +140,7 @@ class Preprocessor
       template_string, dynamic_tokens = parser.parse(tokens)
     end
 
-    if !@template_to_template_id.key?(template_string)
+    unless @template_to_template_id.key?(template_string)
       @template_to_template_id[template_string] = @template_to_template_id_counter
       @template_to_template_id_counter += 1
     end

--- a/lib/logstash/filters/preprocessor.rb
+++ b/lib/logstash/filters/preprocessor.rb
@@ -152,24 +152,4 @@ class Preprocessor
 
     [template_string, dynamic_tokens, template_id]
   end
-
-  # Processes a given seed file log event by tokenizing it and updating the gram dictionary.
-  #
-  # This method is the same as the process_log_event except it doesn't parse the tokens and does not output anything
-  #
-  # Parameters:
-  # log_event [String] the log event to be processed
-  #
-  # Returns:
-  # nil
-  def process_seed_log_event(log_event, threshold)
-    # Split log event into tokens
-    tokens = token_splitter(log_event)
-
-    # If no tokens were returned, do not parse the logs and return
-    return if tokens.nil?
-
-    # Update gram_dict
-    @gram_dict.upload_grams(tokens)
-  end
 end

--- a/lib/logstash/filters/preprocessor.rb
+++ b/lib/logstash/filters/preprocessor.rb
@@ -150,7 +150,7 @@ class Preprocessor
     # Update gram_dict
     @gram_dict.upload_grams(tokens)
 
-    [event_string, template_string, template_id]
+    [template_string, dynamic_tokens, template_id]
   end
 
   # Processes a given seed file log event by tokenizing it and updating the gram dictionary.

--- a/spec/filters/pilar_spec.rb
+++ b/spec/filters/pilar_spec.rb
@@ -11,6 +11,16 @@ describe LogStash::Filters::Pilar do
     pilar_filter.register
   end
 
+  describe 'configuration validation' do
+    context 'when threshold is valid' do
+      let(:config) { { 'threshold' => 0.5 } }
+      
+      it 'registers without errors' do
+        expect { described_class.new(config).register }.not_to raise_error
+      end
+    end
+  end  
+
   describe 'registration' do
     it 'correctly register without errors' do
       expect { pilar_filter }.not_to raise_error
@@ -39,4 +49,18 @@ describe LogStash::Filters::Pilar do
       expect(event.get('raw_log')).to eq(sample_log)
     end
   end
+
+  describe 'line number incrementation' do
+    let(:config) { {} } # Default configuration
+    let(:sample_log) { 'Sample log content' }
+    let(:event1) { LogStash::Event.new('message' => sample_log) }
+    let(:event2) { LogStash::Event.new('message' => sample_log) }
+  
+    it 'increments line_id for each event' do
+      pilar_filter.filter(event1)
+      pilar_filter.filter(event2)
+      expect(event2.get('line_id')).to eq(event1.get('line_id') + 1)
+    end
+  end
+  
 end

--- a/spec/filters/pilar_spec.rb
+++ b/spec/filters/pilar_spec.rb
@@ -13,7 +13,7 @@ describe LogStash::Filters::Pilar do
 
   describe 'configuration validation' do
     context 'when threshold is valid' do
-      let(:config) { { 'threshold' => 0.5 } }
+      let(:config) { { 'dynamic_token_threshold' => 0.5 } }
 
       it 'registers without errors' do
         expect { described_class.new(config).register }.not_to raise_error

--- a/spec/filters/pilar_spec.rb
+++ b/spec/filters/pilar_spec.rb
@@ -14,12 +14,12 @@ describe LogStash::Filters::Pilar do
   describe 'configuration validation' do
     context 'when threshold is valid' do
       let(:config) { { 'threshold' => 0.5 } }
-      
+
       it 'registers without errors' do
         expect { described_class.new(config).register }.not_to raise_error
       end
     end
-  end  
+  end
 
   describe 'registration' do
     it 'correctly register without errors' do
@@ -55,12 +55,11 @@ describe LogStash::Filters::Pilar do
     let(:sample_log) { 'Sample log content' }
     let(:event1) { LogStash::Event.new('message' => sample_log) }
     let(:event2) { LogStash::Event.new('message' => sample_log) }
-  
+
     it 'increments line_id for each event' do
       pilar_filter.filter(event1)
       pilar_filter.filter(event2)
       expect(event2.get('line_id')).to eq(event1.get('line_id') + 1)
     end
   end
-  
 end

--- a/spec/filters/preprocessor_spec.rb
+++ b/spec/filters/preprocessor_spec.rb
@@ -79,17 +79,18 @@ describe Preprocessor do
     end
 
     it 'updates the template_to_template_id mapping for unique log templates' do
-      expect { preprocessor.process_log_event(log_event, threshold) }.to change { preprocessor.instance_variable_get(:@template_to_template_id).length }.by(1)
+      expect { preprocessor.process_log_event(log_event, threshold, true) }.to change { preprocessor.instance_variable_get(:@template_to_template_id).length }.by(1)
     end
 
     it 'does not update the template_to_template_id mapping for repeated log templates' do
-      preprocessor.process_log_event(log_event, threshold)
-      expect { preprocessor.process_log_event(log_event, threshold) }.not_to change { preprocessor.instance_variable_get(:@template_to_template_id).length }
+      preprocessor.process_log_event(log_event, threshold, true)
+      expect { preprocessor.process_log_event(log_event, threshold, true) }.not_to change { preprocessor.instance_variable_get(:@template_to_template_id).length }
     end
+
     context 'when parse is set to false' do
       before do
         allow(Parser).to receive(:new).and_return(double('Parser', parse: nil))
-        preprocessor.process_log_event(log_event, false)
+        preprocessor.process_log_event(log_event, threshold, false)
       end
 
       it 'does not call parser.parse' do
@@ -100,7 +101,7 @@ describe Preprocessor do
     context 'when parse is set to true' do
       before do
         allow(Parser).to receive(:new).and_return(double('Parser', parse: nil))
-        preprocessor.process_log_event(log_event, true)
+        preprocessor.process_log_event(log_event, threshold, true)
       end
 
       it 'does call parser.parse' do

--- a/spec/filters/preprocessor_spec.rb
+++ b/spec/filters/preprocessor_spec.rb
@@ -10,7 +10,8 @@ describe Preprocessor do
   let(:logformat) { '<date> <time> <message>' }
   let(:content_specifier) { 'message' }
   let(:dynamic_token_threshold) { 0.5 }
-  let(:preprocessor) { Preprocessor.new(gram_dict, logformat, content_specifier) }
+  let(:regexes) {["(\d+\.){3}\d+"]}
+  let(:preprocessor) { Preprocessor.new(gram_dict, logformat, content_specifier, regexes) }
 
   describe '#regex_generator' do
     it 'generates a regex based on log format' do

--- a/spec/filters/preprocessor_spec.rb
+++ b/spec/filters/preprocessor_spec.rb
@@ -79,12 +79,16 @@ describe Preprocessor do
     end
 
     it 'updates the template_to_template_id mapping for unique log templates' do
-      expect { preprocessor.process_log_event(log_event, threshold, true) }.to change { preprocessor.instance_variable_get(:@template_to_template_id).length }.by(1)
+      expect { preprocessor.process_log_event(log_event, threshold, true) }.to change {
+                                                                                 preprocessor.instance_variable_get(:@template_to_template_id).length
+                                                                               }.by(1)
     end
 
     it 'does not update the template_to_template_id mapping for repeated log templates' do
       preprocessor.process_log_event(log_event, threshold, true)
-      expect { preprocessor.process_log_event(log_event, threshold, true) }.not_to change { preprocessor.instance_variable_get(:@template_to_template_id).length }
+      expect { preprocessor.process_log_event(log_event, threshold, true) }.not_to(change do
+                                                                                     preprocessor.instance_variable_get(:@template_to_template_id).length
+                                                                                   end)
     end
 
     context 'when parse is set to false' do

--- a/spec/filters/preprocessor_spec.rb
+++ b/spec/filters/preprocessor_spec.rb
@@ -10,7 +10,7 @@ describe Preprocessor do
   let(:logformat) { '<date> <time> <message>' }
   let(:content_specifier) { 'message' }
   let(:dynamic_token_threshold) { 0.5 }
-  let(:regexes) {["(\d+\.){3}\d+"]}
+  let(:regexes) { ["(\d+.){3}\d+"] }
   let(:preprocessor) { Preprocessor.new(gram_dict, logformat, content_specifier, regexes) }
 
   describe '#regex_generator' do
@@ -82,14 +82,18 @@ describe Preprocessor do
 
     it 'updates the template_to_template_id mapping for unique log templates' do
       expect { preprocessor.process_log_event(log_event, threshold, true) }.to change {
-                                                                                 preprocessor.instance_variable_get(:@template_to_template_id).length
+                                                                                 preprocessor.instance_variable_get(
+                                                                                   :@template_to_template_id
+                                                                                 ).length
                                                                                }.by(1)
     end
 
     it 'does not update the template_to_template_id mapping for repeated log templates' do
       preprocessor.process_log_event(log_event, threshold, true)
       expect { preprocessor.process_log_event(log_event, threshold, true) }.not_to(change do
-                                                                                     preprocessor.instance_variable_get(:@template_to_template_id).length
+                                                                                     preprocessor.instance_variable_get(
+                                                                                       :@template_to_template_id
+                                                                                     ).length
                                                                                    end)
     end
 


### PR DESCRIPTION
Changes required for testing to work and some improvements made after testing.

- logformat: This is a field that I noticed we weren't accounting for, in the original code, they have these parsers that help them achieve much higher accuracy, we can ask the user to input these since it should be standard across all logs and improve our accuracy (proof below)
<img width="877" alt="image" src="https://github.com/aaronabraham311/logstash-filter-pilar/assets/53587708/c336a056-831a-4ec6-801b-3e863fecd537">

- content_specifier: This is correlated with logformat, it just says which field from the logformat we extract
- threshold: This is the only parameter for PILAR, not sure why we weren't taking this in already, but this is threshold for a token to be considered dynamic
- line number: this is for testing purposes, need to make sure that each log is labelled in order
- template_to_template_id: this allows us to create the template_id which is important for the group match evaluation script

On some test android data:

**With Seed**
- Precision: 0.8941
- Recall: 0.7939
- F1_measure: 0.8410
- Parsing_Accuracy: 0.4865

**Without Seed**
- Precision: 0.8906
- Recall: 0.7576
- F1_measure: 0.8188
- Parsing_Accuracy: 0.1835

**Without LogFormat**
- Precision: 0.7852
- Recall: 0.6137
- F1_measure: 0.6890
- Parsing_Accuracy: 0.0145
