### PR TITLE
[Feature] Add Support for Multiple Logstash Workers and Cap Gram Dictionary Size 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'lru_redux'
+
 logstash_path = ENV.fetch('LOGSTASH_PATH', nil)
 
 if Dir.exist?(logstash_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,15 +5,15 @@ PATH
       logstash-core-plugin-api (~> 2.0)
 
 PATH
-  remote: /Users/aaronabraham/code/aaronabraham311/logstash-8.11.0/logstash-core-plugin-api
+  remote: /Users/yash/Documents/logstash-8.11.1/logstash-core-plugin-api
   specs:
     logstash-core-plugin-api (2.1.16-java)
-      logstash-core (= 8.11.0)
+      logstash-core (= 8.11.1)
 
 PATH
-  remote: /Users/aaronabraham/code/aaronabraham311/logstash-8.11.0/logstash-core
+  remote: /Users/yash/Documents/logstash-8.11.1/logstash-core
   specs:
-    logstash-core (8.11.0-java)
+    logstash-core (8.11.1-java)
       cgi (~> 0.3.6)
       clamp (~> 1)
       concurrent-ruby (~> 1, < 1.1.10)
@@ -49,16 +49,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    base64 (0.2.0)
     cgi (0.3.6-java)
     clamp (1.3.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     date (3.3.4-java)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     down (5.2.4)
       addressable (~> 2.8)
     e2mmap (0.1.0)
@@ -71,11 +70,10 @@ GEM
       faraday (>= 1, < 3)
       multi_json
     execjs (2.9.1)
-    faraday (2.7.11)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     ffi (1.15.5-java)
     ffi-binary-libfixposix (0.5.1.1-java)
       ffi (~> 1.0)
@@ -85,10 +83,10 @@ GEM
     gems (1.2.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    io-console (0.6.0-java)
+    io-console (0.7.2-java)
     jrjackson (0.4.18-java)
-    jruby-openssl (0.14.2-java)
-    json (2.6.3-java)
+    jruby-openssl (0.14.3-java)
+    json (2.7.1-java)
     kramdown (2.4.0)
       rexml
     language_server-protocol (3.17.0.3)
@@ -96,7 +94,7 @@ GEM
       logstash-core-plugin-api (>= 1.60, <= 2.99)
       logstash-mixin-ecs_compatibility_support (~> 1.3)
       logstash-mixin-event_support (~> 1.0)
-    logstash-devutils (2.5.0-java)
+    logstash-devutils (2.6.2-java)
       fivemat
       gem_publisher
       kramdown (~> 2)
@@ -111,6 +109,7 @@ GEM
       logstash-core (>= 6.0.0)
     logstash-mixin-event_support (1.0.1-java)
       logstash-core (>= 6.8)
+    lru_redux (1.1.0)
     manticore (0.9.1-java)
       openssl_pkcs8_pure
     method_source (1.0.0)
@@ -122,10 +121,10 @@ GEM
       uri
     net-protocol (0.1.3)
       timeout
-    nio4r (2.5.9-java)
+    nio4r (2.7.0-java)
     openssl_pkcs8_pure (0.0.0.2)
-    parallel (1.23.0)
-    parser (3.2.2.4)
+    parallel (1.24.0)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     pluginator (1.5.0)
@@ -136,8 +135,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
       spoon (~> 0.0)
-    public_suffix (5.0.3)
-    puma (6.4.0-java)
+    public_suffix (5.0.4)
+    puma (6.4.2-java)
       nio4r (~> 2.0)
     racc (1.7.3-java)
     rack (2.2.8)
@@ -145,34 +144,34 @@ GEM
       rack
     rainbow (3.1.1)
     rake (13.1.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.9.0)
     reline (0.3.9)
       io-console (~> 0.5)
     rexml (3.2.6)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.0)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
-    rubocop (1.57.2)
+    rubocop (1.60.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
@@ -199,13 +198,12 @@ GEM
       polyglot (~> 0.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2023.3)
+    tzinfo-data (1.2024.1)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
     uri (0.12.2)
 
 PLATFORMS
-  universal-java-11
   universal-java-21
 
 DEPENDENCIES
@@ -214,6 +212,7 @@ DEPENDENCIES
   logstash-core-plugin-api!
   logstash-devutils
   logstash-filter-pilar!
+  lru_redux
   pre-commit
   rspec (~> 3.12)
   rubocop

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ bundle install
 - Run tests
 
 ```sh
-bundle exec bin/rspec
+bundle exec rspec
 ```
 
 ### 2. Running your unpublished Plugin in Logstash

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ bundle install
 - Run tests
 
 ```sh
-bundle exec rspec
+bundle exec bin/rspec
 ```
 
 ### 2. Running your unpublished Plugin in Logstash

--- a/lib/logstash/filters/gramdict.rb
+++ b/lib/logstash/filters/gramdict.rb
@@ -16,9 +16,11 @@ require 'lru_redux'
 # and anomalies in log entries.
 class GramDict
   def initialize(max_gram_dict_size)
-    @tri_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
-    @double_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
-    @single_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
+    # print "YASH YASH YASH YASH YASH ITS NEW GRAM DICT TIME YASH YASH YASH "
+
+    @tri_gram_dict = LruRedux::ThreadSafeCache.new(max_gram_dict_size)
+    @double_gram_dict = LruRedux::ThreadSafeCache.new(max_gram_dict_size)
+    @single_gram_dict = LruRedux::ThreadSafeCache.new(max_gram_dict_size)
   end
 
   # Method: single_gram_upload

--- a/lib/logstash/filters/gramdict.rb
+++ b/lib/logstash/filters/gramdict.rb
@@ -16,11 +16,12 @@ require 'lru_redux'
 # and anomalies in log entries.
 class GramDict
   def initialize(max_gram_dict_size)
-    # print "YASH YASH YASH YASH YASH ITS NEW GRAM DICT TIME YASH YASH YASH "
+    print "YASH YASH YASH YASH YASH ITS NEW GRAM DICT TIME YASH YASH YASH "
 
-    @tri_gram_dict = LruRedux::ThreadSafeCache.new(max_gram_dict_size)
-    @double_gram_dict = LruRedux::ThreadSafeCache.new(max_gram_dict_size)
-    @single_gram_dict = LruRedux::ThreadSafeCache.new(max_gram_dict_size)
+    @max_gram_dict_size = max_gram_dict_size
+    @tri_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
+    @double_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
+    @single_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
   end
 
   # Method: single_gram_upload
@@ -144,5 +145,10 @@ class GramDict
       trigram = first_token + token_seperator + second_token + token_seperator + token
       tri_gram_upload(trigram)
     end
+  end
+
+  def clone
+    new_gram_dict = GramDict.new(@max_gram_dict_size)
+    new_gram_dict
   end
 end

--- a/lib/logstash/filters/gramdict.rb
+++ b/lib/logstash/filters/gramdict.rb
@@ -16,7 +16,6 @@ require 'lru_redux'
 # and anomalies in log entries.
 class GramDict
   def initialize(max_gram_dict_size)
-    print "YASH YASH YASH YASH YASH ITS NEW GRAM DICT TIME YASH YASH YASH "
 
     @max_gram_dict_size = max_gram_dict_size
     @tri_gram_dict = LruRedux::Cache.new(max_gram_dict_size)

--- a/lib/logstash/filters/gramdict.rb
+++ b/lib/logstash/filters/gramdict.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'lru_redux'
 
 # The GramDict class is designed for processing and analyzing log events.
 # It creates dictionaries for single, double, triple, and four-word combinations
@@ -14,10 +15,10 @@
 # This class is useful for log file analysis, especially for identifying common patterns
 # and anomalies in log entries.
 class GramDict
-  def initialize
-    @tri_gram_dict = {}
-    @double_gram_dict = {}
-    @single_gram_dict = {}
+  def initialize(max_gram_dict_size)
+    @tri_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
+    @double_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
+    @single_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
   end
 
   # Method: single_gram_upload

--- a/lib/logstash/filters/gramdict.rb
+++ b/lib/logstash/filters/gramdict.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'lru_redux'
 
 # The GramDict class is designed for processing and analyzing log events.
@@ -16,7 +17,6 @@ require 'lru_redux'
 # and anomalies in log entries.
 class GramDict
   def initialize(max_gram_dict_size)
-
     @max_gram_dict_size = max_gram_dict_size
     @tri_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
     @double_gram_dict = LruRedux::Cache.new(max_gram_dict_size)
@@ -144,10 +144,5 @@ class GramDict
       trigram = first_token + token_seperator + second_token + token_seperator + token
       tri_gram_upload(trigram)
     end
-  end
-
-  def clone
-    new_gram_dict = GramDict.new(@max_gram_dict_size)
-    new_gram_dict
   end
 end

--- a/lib/logstash/filters/parser.rb
+++ b/lib/logstash/filters/parser.rb
@@ -84,7 +84,7 @@ class Parser
     singlegram = tokens[index - 1]
     doublegram = "#{singlegram}^#{tokens[index]}"
 
-    if @gramdict.double_gram_dict.include?(doublegram) && @gramdict.single_gram_dict.include?(singlegram)
+    if @gramdict.double_gram_dict.key?(doublegram) && @gramdict.single_gram_dict.key?(singlegram)
       @gramdict.double_gram_dict[doublegram].to_f / @gramdict.single_gram_dict[singlegram]
     else
       0
@@ -107,7 +107,7 @@ class Parser
     doublegram = "#{tokens[index - 2]}^#{tokens[index - 1]}"
     trigram = "#{doublegram}^#{tokens[index]}"
 
-    if @gramdict.tri_gram_dict.include?(trigram) && @gramdict.double_gram_dict.include?(doublegram)
+    if @gramdict.tri_gram_dict.key?(trigram) && @gramdict.double_gram_dict.key?(doublegram)
       @gramdict.tri_gram_dict[trigram].to_f / @gramdict.double_gram_dict[doublegram]
     else
       0

--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -50,45 +50,60 @@ module LogStash
       config :maximum_gram_dict_size, validate: :number, required: false, default: 10000
 
       def register
+        # print "RUNNING ON WORKER ID " + @id 
+        worker_id = Thread.current.object_id.to_s
+        puts "REGISTER ON WORKER ID #{worker_id}\n"
         @linenumber = 1
         @regexes = regexes.map { |regex| Regexp.new(regex) }
-        @gramdict = GramDict.new(@maximum_gram_dict_size).clone
-        @preprocessor = Preprocessor.new(@gramdict, @logformat, @content_specifier, @regexes)
+        # @gramdict = GramDict.new(@maximum_gram_dict_size).clone
+        # @preprocessor = Preprocessor.new(@gramdict, @logformat, @content_specifier, @regexes)
 
         # Check if dynamic_token_threshold is between 0 and 1
         if @dynamic_token_threshold < 0.0 || @dynamic_token_threshold > 1.0
           raise LogStash::ConfigurationError, 'dynamic_token_threshold must be between 0 and 1'
         end
-
-        # populate gramdict with seed logs
-        return unless @seed_logs_path
-
-        ::File.open(@seed_logs_path, 'r') do |seed_logs|
-          seed_logs.each_line do |seed_log|
-            # TODO: Here, we are parsing every seed log file when we don't need to,
-            # might need to separate these steps out
-            @preprocessor.process_log_event(seed_log, false)
-          end
-        end
       end
 
       def filter(event)
+
+          # Initialize gramdict and preprocessor for this thread if not already done
+          unless Thread.current[:gramdict] && Thread.current[:preprocessor]
+            Thread.current[:gramdict] = GramDict.new(@maximum_gram_dict_size)
+            Thread.current[:preprocessor] = Preprocessor.new(Thread.current[:gramdict], @logformat, @content_specifier, @regexes)
+
+            # Populate gramdict with seed logs
+            if @seed_logs_path && ::File.exist?(@seed_logs_path)
+              ::File.open(@seed_logs_path, 'r') do |seed_logs|
+                seed_logs.each_line do |seed_log|
+                  Thread.current[:preprocessor].process_log_event(seed_log, false)
+                end
+              end
+            end
+          end
+
+          
         # Use the message from the specified source field
         if event.get(@source_field)
           start_time = Time.now
-          processed_log = @preprocessor.process_log_event(
-            event.get(@source_field), @dynamic_token_threshold, true
-          )
 
-          if processed_log
-            template_string, dynamic_tokens = processed_log
 
-            # Set the new values in the returned event
-            event.set('template_string', template_string)
-            event.set('dynamic_tokens', dynamic_tokens)
-          else
-            event.set('dynamic_tokens', nil)
-            event.set('template_string', nil)
+
+          if event.get(@source_field)
+
+            processed_log = Thread.current[:preprocessor].process_log_event(
+              event.get(@source_field), @dynamic_token_threshold, true
+            )
+
+            if processed_log
+              template_string, dynamic_tokens = processed_log
+
+              # Set the new values in the returned event
+              event.set('template_string', template_string)
+              event.set('dynamic_tokens', dynamic_tokens)
+            else
+              event.set('dynamic_tokens', nil)
+              event.set('template_string', nil)
+            end
           end
 
           # include the raw log message

--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -52,7 +52,7 @@ module LogStash
       def register
         @linenumber = 1
         @regexes = regexes.map { |regex| Regexp.new(regex) }
-        @gramdict = GramDict.new(@maximum_gram_dict_size)
+        @gramdict = GramDict.new(@maximum_gram_dict_size).clone
         @preprocessor = Preprocessor.new(@gramdict, @logformat, @content_specifier, @regexes)
 
         # Check if dynamic_token_threshold is between 0 and 1
@@ -75,6 +75,7 @@ module LogStash
       def filter(event)
         # Use the message from the specified source field
         if event.get(@source_field)
+          start_time = Time.now
           processed_log = @preprocessor.process_log_event(
             event.get(@source_field), @dynamic_token_threshold, true
           )
@@ -96,6 +97,9 @@ module LogStash
         end
 
         # Emit event
+        end_time = Time.now
+        duration  = end_time - start_time 
+        event.set('processing_duration', duration)
         filter_matched(event)
       end
     end

--- a/lib/logstash/filters/pilar.rb
+++ b/lib/logstash/filters/pilar.rb
@@ -44,10 +44,15 @@ module LogStash
       # ['(\d+\.){3}\d+'] for IP addresses to be extracted before parsing begins.
       config :regexes, validate: :array, required: false, default: []
 
+      # This determines the maximum size of the single, double, and triple gram dictionaries respectively.
+      # Upon any of those hash maps reaching their maximum size, a LRU evicition policy is used to remove items. 
+      # This controls the upper limit of the memory usage of this filter.
+      config :maximum_gram_dict_size, validate: :number, required: false, default: 10000
+
       def register
         @linenumber = 1
         @regexes = regexes.map { |regex| Regexp.new(regex) }
-        @gramdict = GramDict.new
+        @gramdict = GramDict.new(@maximum_gram_dict_size)
         @preprocessor = Preprocessor.new(@gramdict, @logformat, @content_specifier, @regexes)
 
         # Check if dynamic_token_threshold is between 0 and 1

--- a/lib/logstash/filters/preprocessor.rb
+++ b/lib/logstash/filters/preprocessor.rb
@@ -162,9 +162,7 @@ class Preprocessor
 
     # Split log event into tokens
     tokens, preprocessed_dynamic_token = token_splitter(log_event)
-    if preprocessed_dynamic_token
-      all_dynamic_tokens.merge(preprocessed_dynamic_token)
-    end
+    all_dynamic_tokens.merge(preprocessed_dynamic_token) if preprocessed_dynamic_token
 
     # If no tokens were returned, do not parse the logs and return
     return if tokens.nil?
@@ -178,9 +176,7 @@ class Preprocessor
       # there should be no conflicts here as long as all preprocess_known_dynamic_tokens have
       # the format "[global/manual]_preprocessed_dynamic_token_{i}" and all the dynamic tokens have the
       # format "dynamic_token_{i}"
-      if dynamic_tokens
-        all_dynamic_tokens.merge(dynamic_tokens)
-      end
+      all_dynamic_tokens.merge(dynamic_tokens) if dynamic_tokens
     end
 
     # Update gram_dict

--- a/spec/filters/gramdict_spec.rb
+++ b/spec/filters/gramdict_spec.rb
@@ -6,8 +6,9 @@ require 'logstash/filters/gramdict'
 
 describe GramDict do
   let(:logformat) { '<date> <time> <message>' }
+  let(:max_gram_dict_size) { 10000 }
 
-  subject { GramDict.new }
+  subject { GramDict.new(max_gram_dict_size) }
 
   describe '#single_gram_upload' do
     let(:gram) { 'example' }
@@ -52,8 +53,8 @@ describe GramDict do
       it 'updates only the single gram dictionary' do
         expect { subject.upload_grams(tokens) }
           .to change { subject.single_gram_dict['token1'] }.from(nil).to(1)
-        expect(subject.double_gram_dict).to be_empty
-        expect(subject.tri_gram_dict).to be_empty
+        expect(subject.double_gram_dict.count).to eq(0)
+        expect(subject.tri_gram_dict.count).to eq(0)
       end
     end
 
@@ -66,7 +67,7 @@ describe GramDict do
           .to change { subject.single_gram_dict['token1'] }.from(nil).to(1)
           .and change { subject.single_gram_dict['token2'] }.from(nil).to(1)
           .and change { subject.double_gram_dict[double_gram] }.from(nil).to(1)
-        expect(subject.tri_gram_dict).to be_empty
+        expect(subject.tri_gram_dict.count).to eq(0)
       end
     end
 

--- a/spec/filters/gramdict_spec.rb
+++ b/spec/filters/gramdict_spec.rb
@@ -6,7 +6,7 @@ require 'logstash/filters/gramdict'
 
 describe GramDict do
   let(:logformat) { '<date> <time> <message>' }
-  let(:max_gram_dict_size) { 10000 }
+  let(:max_gram_dict_size) { 10_000 }
 
   subject { GramDict.new(max_gram_dict_size) }
 

--- a/spec/filters/parser_spec.rb
+++ b/spec/filters/parser_spec.rb
@@ -11,7 +11,7 @@ describe Parser do
 
   # Create an instance of GramDict
   let(:gramdict) do
-    gd = GramDict.new(10000)
+    gd = GramDict.new(10_000)
 
     # Manually setting the dictionaries
     gd.instance_variable_set(:@single_gram_dict, { 'token2a' => 2, 'key2' => 2 })

--- a/spec/filters/parser_spec.rb
+++ b/spec/filters/parser_spec.rb
@@ -11,7 +11,7 @@ describe Parser do
 
   # Create an instance of GramDict
   let(:gramdict) do
-    gd = GramDict.new
+    gd = GramDict.new(10000)
 
     # Manually setting the dictionaries
     gd.instance_variable_set(:@single_gram_dict, { 'token2a' => 2, 'key2' => 2 })

--- a/spec/filters/preprocessor_spec.rb
+++ b/spec/filters/preprocessor_spec.rb
@@ -6,7 +6,7 @@ require 'logstash/filters/preprocessor'
 require 'logstash/filters/gramdict'
 
 describe Preprocessor do
-  let(:gram_dict) { GramDict.new(10000) }
+  let(:gram_dict) { GramDict.new(10_000) }
   let(:logformat) { '<date> <time> <message>' }
   let(:content_specifier) { 'message' }
   let(:dynamic_token_threshold) { 0.5 }

--- a/spec/filters/preprocessor_spec.rb
+++ b/spec/filters/preprocessor_spec.rb
@@ -6,7 +6,7 @@ require 'logstash/filters/preprocessor'
 require 'logstash/filters/gramdict'
 
 describe Preprocessor do
-  let(:gram_dict) { GramDict.new }
+  let(:gram_dict) { GramDict.new(10000) }
   let(:logformat) { '<date> <time> <message>' }
   let(:content_specifier) { 'message' }
   let(:dynamic_token_threshold) { 0.5 }

--- a/spec/filters/preprocessor_spec.rb
+++ b/spec/filters/preprocessor_spec.rb
@@ -36,7 +36,7 @@ describe Preprocessor do
 
     context 'with general regexes applied' do
       it 'replaces both specific and general dynamic tokens with "<*>"' do
-        processed_log = preprocessor.preprocess_known_dynamic_tokens(log_line, regexes)
+        processed_log, preprocessed_dynamic_token = preprocessor.preprocess_known_dynamic_tokens(log_line, regexes)
         expect(processed_log).not_to include('192.168.1.1')
         expect(processed_log).not_to include('User')
         expect(processed_log).to include('<*>').twice


### PR DESCRIPTION
### This PR aims to address two issues:

- The `gramdict` class can grow indefinitely in size due to its use of hash maps,  thus causing unbounded memory usage
- The `gramdict` class is not being properly initialized once per worker, causing race conditions as multiple workers attempt to access the same data. 

### It does this by implementing the following:

- Use the `lru_redux` gem to create a hash map with a fixed maximum size, ensuring memory usage stays within bounds. Upon exceeding the maximum size, the LRU cache eviction policy is used. The `lru_redux` library is used as it is a gem that has historically been used by other logstash filter plugins 
- Use [thread local variables](https://medium.com/double-pointer/concurrency-in-ruby-thread-variables-4ca94c8267a7#:~:text=A%20thread%2Dlocal%20variable%20is,the%20instance%20method%20thread_variable_set()%20.) to create a unique gramdict and preprocessor class for each Logstash worker, preventing race conditions and improving performance. I'll expand on the rationale behind this in the next section.

### Why use thread local variables?

Currently, the logstash plugin has two methods: `register` and `filter`. 


Let's say you start the plugin with 8 workers (and since each worker corresponds to a thread, you request 8 threads). The plugin will actually use 9 threads. One thread will run the `register` function, and the other 8 will be used as worker threads for each instance of the `filter` function.

This means that you have to initialize a `gramdict` class in the `filter` method if you would like to create one instance of the class per worker. The easiest way to do this is to initialize a `gramdict` on whatever thread the filter function is running on using thread local variables. This becomes the equivalent of creating a `gramdict` class per worker. 

Furthermore, whenever a `gramdict` class is initialized per worker, we also feed the seed data in, thus meaning that each worker gets the starting seed file context it needs. 